### PR TITLE
ci: set up semantic pull requests

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -1,0 +1,19 @@
+name: Semantic Pull Request
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  semantic-pull-request:
+    name: Check pull request title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 # django-xlsx-serializer
 
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-fa6673.svg?style=flat-square&logo=conventional-commits)][conventional-commits]
+
 ## Authors
 
 Created and maintained by Kamil Paduszyński ([@paduszyk][paduszyk]).
@@ -8,5 +10,6 @@ Created and maintained by Kamil Paduszyński ([@paduszyk][paduszyk]).
 
 Released under the [MIT license][license].
 
+[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
 [license]: https://github.com/paduszyk/django-xlsx-serializer/blob/main/LICENSE
 [paduszyk]: https://github.com/paduszyk


### PR DESCRIPTION
This adopts the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format for pull request titles using [@amannn/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request).