### PR TITLE
chore: configure Pre-commit runs and auto-updates

### DIFF
--- a/.github/workflows/pre-commit-run.yml
+++ b/.github/workflows/pre-commit-run.yml
@@ -1,0 +1,18 @@
+name: "Pre-commit: Run"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  pre-commit-run:
+    name: Run Pre-commit hooks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -1,0 +1,26 @@
+name: "Pre-commit: Update"
+
+on:
+  schedule:
+    - cron: 0 0 * * 1
+
+jobs:
+  pre-commit-update:
+    name: Update Pre-commit hooks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          cache: pip
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install pre-commit
+      - run: pre-commit autoupdate
+      - uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.CREATE_PR_ACTION_TOKEN }}
+          branch: chore/pre-commit-update
+          commit-message: "chore(deps): update Pre-commit hooks"
+          title: "chore(deps): update Pre-commit hooks"
+          body: |
+            Automated changes by [@peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request) action.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+# Pre-commit
+# https://pre-commit.com
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: "v4.6.0"
+    hooks:
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-toml
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v4.0.0-alpha.8"
+    hooks:
+      - id: prettier
+        args:
+          - --no-error-on-unmatched-pattern
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: "v0.13.0"
+    hooks:
+      - id: markdownlint-cli2

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 # django-xlsx-serializer
 
+[![Pre-commit](https://img.shields.io/github/actions/workflow/status/paduszyk/django-xlsx-serializer/pre-commit-run.yml?style=flat-square&label=pre-commit&logo=pre-commit)][pre-commit]
+
 [![Prettier](https://img.shields.io/badge/code%20style-prettier-1E2B33?style=flat-square&logo=Prettier)][prettier]
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-fa6673.svg?style=flat-square&logo=conventional-commits)][conventional-commits]
 
@@ -14,4 +16,5 @@ Released under the [MIT license][license].
 [conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
 [license]: https://github.com/paduszyk/django-xlsx-serializer/blob/main/LICENSE
 [paduszyk]: https://github.com/paduszyk
+[pre-commit]: https://github.com/paduszyk/django-xlsx-serializer/actions/workflows/pre-commit-run.yml
 [prettier]: https://prettier.io

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,9 @@ dynamic = ["version"]
 "Repository" = "https://github.com/paduszyk/django-xlsx-serializer"
 
 [project.optional-dependencies]
-dev = []
+dev = [
+  "pre-commit < 4",
+]
 
 # Setuptools
 # https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html


### PR DESCRIPTION
[Pre-commit](https://pre-commit.com) runs and auto-updates are set up to perform basic checks of the committed changes using standard ("native") hooks as well as all the linters added before in #2 and #3.