### PR TITLE
chore: lint and auto-format Python with Ruff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ __pycache__/
 *.egg-info/
 build/
 dist/
+
+# Ruff
+.ruff_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,10 @@ repos:
     rev: "v0.13.0"
     hooks:
       - id: markdownlint-cli2
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.4.4"
+    hooks:
+      - id: ruff
+      - id: ruff-format
+        args:
+          - --diff

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,7 @@
 
 [![Pre-commit](https://img.shields.io/github/actions/workflow/status/paduszyk/django-xlsx-serializer/pre-commit-run.yml?style=flat-square&label=pre-commit&logo=pre-commit)][pre-commit]
 
+[![Ruff](https://img.shields.io/endpoint?style=flat-square&url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)][ruff]
 [![Prettier](https://img.shields.io/badge/code%20style-prettier-1E2B33?style=flat-square&logo=Prettier)][prettier]
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-fa6673.svg?style=flat-square&logo=conventional-commits)][conventional-commits]
 
@@ -18,3 +19,4 @@ Released under the [MIT license][license].
 [paduszyk]: https://github.com/paduszyk
 [pre-commit]: https://github.com/paduszyk/django-xlsx-serializer/actions/workflows/pre-commit-run.yml
 [prettier]: https://prettier.io
+[ruff]: https://docs.astral.sh/ruff/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 dev = [
   "pre-commit < 4",
+  "ruff < 1",
 ]
 
 # Setuptools
@@ -50,3 +51,21 @@ dev = [
 
 [tool.setuptools.dynamic]
 version = { attr = "xlsx_serializer.__version__" }
+
+# Ruff
+# https://docs.astral.sh/ruff/configuration/
+# https://docs.astral.sh/ruff/rules/
+# https://docs.astral.sh/ruff/settings/
+
+[tool.ruff]
+target-version = "py39"
+
+[tool.ruff.lint]
+select = ["ALL"]
+ignore = ["D"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["xlsx_serializer"]
+required-imports = [
+  "from __future__ import annotations",
+]


### PR DESCRIPTION
[Ruff](https://docs.astral.sh/ruff/) is installed and configured as the default linter and formatter of the Python codebase forming the project.