### PR TITLE
build: set up Django for the app development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# A template to set up environment variables loaded by Django in the local development.
+
+# Instructions
+# ============
+# 1. Make a copy of this file.
+# 2. Rename the file copied to `.env`.
+# 3. Fill out or update all the placeholders listed below.
+
+# Default database engine
+# =======================
+# Use one of the keys available from the database configs defined in `tests.settings`.
+
+DATABASE_ENGINE=
+
+
+# PostgreSQL database configuration
+# =================================
+
+POSTGRES_NAME=
+POSTGRES_HOST=
+POSTGRES_PORT=
+POSTGRES_USER=
+POSTGRES_PASSWORD=

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@ dist/
 # Coverage.py
 .coverage
 coverage.xml
+
+# Django
+*.sqlite3
+
+# Environment variables
+.env

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,7 @@ repos:
     rev: "v1.10.0"
     hooks:
       - id: mypy
+        additional_dependencies:
+          - django-stubs[compatible-mypy] < 6
+          - psycopg2-binary < 3
+          - python-dotenv < 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "django-xlsx-serializer"
 dependencies = [
+  "django >= 3.2, < 5.1",
   "typing-extensions < 5",
 ]
 requires-python = ">= 3.9"
@@ -25,6 +26,12 @@ keywords = [
 ]
 classifiers = [
   "Environment :: Web Environment",
+  "Framework :: Django",
+  "Framework :: Django :: 3.2",
+  "Framework :: Django :: 4.0",
+  "Framework :: Django :: 4.1",
+  "Framework :: Django :: 4.2",
+  "Framework :: Django :: 5.0",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
@@ -44,11 +51,14 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = [
-  "mypy < 2",
+  "django-stubs[compatible-mypy] < 6",
   "pre-commit < 4",
   "pytest < 9",
   "pytest-cov < 6",
+  "pytest-django < 5",
   "pytest-custom-exit-code < 1",
+  "psycopg2-binary < 3",
+  "python-dotenv < 2",
   "ruff < 1",
 ]
 
@@ -71,7 +81,7 @@ select = ["ALL"]
 ignore = ["ANN", "D"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["ARG", "E501", "FBT", "PLR2004", "S101"]
+"tests/**/*.py" = ["ARG", "DJ", "E501", "FBT", "PLR2004", "S101"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["xlsx_serializer"]
@@ -82,13 +92,21 @@ section-order = [
   "future",
   "standard-library",
   "third-party",
+  "django",
   "first-party",
   "tests",
   "local-folder",
 ]
 
 [tool.ruff.lint.isort.sections]
+"django" = ["django"]
 "tests" = ["tests"]
+
+[tool.ruff.lint.flake8-self]
+extend-ignore-names = [
+  "_default_manager",
+  "_meta",
+]
 
 # Mypy
 # https://mypy.readthedocs.io/en/stable/config_file.html
@@ -99,6 +117,9 @@ exclude = [
   "^build/",
 ]
 strict = true
+plugins = [
+  "mypy_django_plugin.main",
+]
 
 [[tool.mypy.overrides]]
 module = [
@@ -111,6 +132,13 @@ module = [
   "tests.*",
 ]
 disallow_untyped_decorators = false
+
+# Django-stubs
+# https://github.com/typeddjango/django-stubs
+
+[tool.django-stubs]
+django_settings_module = "tests.settings"
+strict_settings = false
 
 # Pytest
 # https://docs.pytest.org/en/latest/reference/reference.html#configuration-options
@@ -127,6 +155,9 @@ addopts = [
   # pytest-custom-exit-code
   # https://github.com/yashtodi94/pytest-custom_exit_code?tab=readme-ov-file#usage
   "--suppress-no-test-exit-code",
+  # pytest-django
+  # https://pytest-django.readthedocs.io/en/latest/usage.html#usage-and-invocations
+  "--ds=tests.settings",
 ]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+__all__ = [
+    "DATABASES",
+    "DEFAULT_AUTO_FIELD",
+    "INSTALLED_APPS",
+]
+
+import os
+
+from django.core.exceptions import ImproperlyConfigured
+from django.db import DEFAULT_DB_ALIAS
+
+# Detect CI environment.
+
+CI_VARIABLES = [
+    "GITHUB_ACTIONS",
+]
+
+CI_RUN = any(map(os.getenv, CI_VARIABLES))
+
+if not CI_RUN:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+
+
+# Databases.
+
+DATABASE_CONFIGS = {
+    "dummy": {
+        "ENGINE": "django.db.backends.dummy",
+    },
+    "postgresql": {
+        "ENGINE": "django.db.backends.postgresql",
+        # If Django is run on CI, use the `postgres` Docker image:
+        # https://hub.docker.com/_/postgres
+        **(
+            {
+                "NAME": "postgres",
+                "HOST": "localhost",
+                "PORT": "5432",
+                "USER": "postgres",
+                "PASSWORD": "postgres",
+            }
+            if CI_RUN
+            # Otherwise, read the configuration from local environment variables.
+            # The variables can be set in the `.env` file, see `.env.example`.
+            else {
+                "NAME": os.getenv("POSTGRES_NAME", "postgres"),
+                "HOST": os.getenv("POSTGRES_HOST", "localhost"),
+                "PORT": os.getenv("POSTGRES_PORT", "5432"),
+                "USER": os.getenv("POSTGRES_USER", "postgres"),
+                "PASSWORD": os.getenv("POSTGRES_PASSWORD", "postgres"),
+            }
+        ),
+    },
+    "sqlite3": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:" if CI_RUN else "db.sqlite3",
+    },
+}
+
+DATABASE_ENGINE = os.getenv("DATABASE_ENGINE", "dummy")
+
+try:
+    DATABASES = {
+        DEFAULT_DB_ALIAS: DATABASE_CONFIGS[DATABASE_ENGINE],
+    }
+except KeyError as e:
+    msg = (
+        f"{DATABASE_ENGINE!r} isn't a valid value for the 'DATABASE_ENGINE' variable "
+        f"(use one of the following: {', '.join(map(repr, DATABASE_CONFIGS))})"
+    )
+    raise ImproperlyConfigured(msg) from e
+
+
+# Models.
+
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
+
+# Apps.
+
+INSTALLED_APPS = [
+    "xlsx_serializer",
+    "tests",
+]


### PR DESCRIPTION
The app is installed and configured in a simple [Django](https://www.djangoproject.com) project (within the `tests.settings` module). Besides, linter/formatter (#6), type-checker (#7), and test runner (#8)  are re-configured to work with Django properly.