### PR TITLE
ci: upload coverage reports to Codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,16 @@
+# Codecov YAML
+# https://docs.codecov.com/docs/codecovyml-reference
+
+codecov:
+  branch: main
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0%
+    patch:
+      default:
+        target: auto
+        threshold: 0%

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -110,3 +110,18 @@ jobs:
       - run: python -m pip install --upgrade pip
       - run: python -m pip install nox
       - run: nox --session "${{ matrix.session.name }}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.session.name }}
+          path: coverage.xml
+  codecov-upload:
+    name: Uplaod coverage to Codecov
+    needs:
+      - test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,7 @@
 
 [![Pre-commit](https://img.shields.io/github/actions/workflow/status/paduszyk/django-xlsx-serializer/pre-commit-run.yml?style=flat-square&label=pre-commit&logo=pre-commit)][pre-commit]
 [![Python: CI](https://img.shields.io/github/actions/workflow/status/paduszyk/django-xlsx-serializer/python-ci.yml?style=flat-square&logo=github&label=CI)][python-ci]
+[![Codecov](https://img.shields.io/codecov/c/github/paduszyk/django-xlsx-serializer?style=flat-square&logo=codecov)][codecov]
 
 [![Nox](https://img.shields.io/badge/%F0%9F%A6%8A-Nox-D85E00.svg?style=flat-square)][nox]
 [![Ruff](https://img.shields.io/endpoint?style=flat-square&url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)][ruff]
@@ -17,6 +18,7 @@ Created and maintained by Kamil Paduszyński ([@paduszyk][paduszyk]).
 
 Released under the [MIT license][license].
 
+[codecov]: https://app.codecov.io/gh/paduszyk/django-xlsx-serializer
 [conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
 [license]: https://github.com/paduszyk/django-xlsx-serializer/blob/main/LICENSE
 [mypy]: https://mypy.readthedocs.io


### PR DESCRIPTION
Uploading the coverage reports to [Codecov](https://codecov.io) is set up to follow the successful Pytest runs in the `test` job of the main CI workflow (#11).