### PR TITLE
build: install openpyxl and types-openpyxl

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,5 +34,7 @@ repos:
       - id: mypy
         additional_dependencies:
           - django-stubs[compatible-mypy] < 6
+          - openpyxl < 4
           - psycopg2-binary < 3
           - python-dotenv < 2
+          - types-openpyxl < 4

--- a/noxfile.py
+++ b/noxfile.py
@@ -73,6 +73,7 @@ def mypy(session: nox.Session) -> None:
         "django-stubs[compatible-mypy] < 6",
         "psycopg2-binary < 3",
         "python-dotenv < 2",
+        "types-openpyxl < 4",
     )
 
     session.run("mypy", *MYPY_OPTIONS, ".")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ build-backend = "setuptools.build_meta"
 name = "django-xlsx-serializer"
 dependencies = [
   "django >= 3.2, < 5.1",
+  "openpyxl < 4",
   "typing-extensions < 5",
 ]
 requires-python = ">= 3.9"
@@ -61,6 +62,7 @@ dev = [
   "psycopg2-binary < 3",
   "python-dotenv < 2",
   "ruff < 1",
+  "types-openpyxl < 4",
 ]
 
 # Setuptools


### PR DESCRIPTION
This adds [`openpyxl`](https://openpyxl.readthedocs.io) to dependencies as well as `types-openpyxl` to dev-dependencies for type annotations support.