### PR TITLE
docs: add usage/contributing guides and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,49 @@
+name: Bug Report
+description: >-
+  File a bug.
+labels:
+  - needs triage
+body:
+  - type: textarea
+    id: versions
+    attributes:
+      label: Versions
+      description: >-
+        Provide versions for all environment components that may relate to the issue.
+      value: |
+        * Package: -
+        * Python: -
+        * Django: -
+        * Excel: -
+        * OS / Platform: -
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: >-
+        Describe the unexpected behavior being a matter of the issue.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: >-
+        Provide a [minimal reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) demonstrating the issue.
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Terms
+      description: >-
+        Before submitting the issue, confirm the following:
+      options:
+        - label: >-
+            I have read and followed the project's
+            [Code of Conduct](https://github.com/paduszyk/django-xlsx-serializer/blob/main/docs/CODE_OF_CONDUCT.md) and
+            [Contributing Guide](https://github.com/paduszyk/django-xlsx-serializer/blob/main/docs/CONTRIBUTING.md).
+          required: true
+        - label: >-
+            I checked that this issue isn't a duplicate.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,15 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Code of Conduct
+    url: https://github.com/paduszyk/django-xlsx-serializer/blob/main/docs/CODE_OF_CONDUCT.md
+    about: |
+      All contributors must agree to follow our Code of Conduct.
+  - name: Contributing Guide
+    url: https://github.com/paduszyk/django-xlsx-serializer/blob/main/docs/CONTRIBUTING.md
+    about: |
+      Please read through before making any contribution.
+  - name: GitHub Community Guidelines
+    url: https://docs.github.com/en/site-policy/github-terms/github-community-guidelines
+    about: |
+      The article discussing GitHub's rules for user behavior and community conduct.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,29 @@
+name: Documentation
+description: >-
+  Suggest how to improve the documentation.
+labels:
+  - needs triage
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: >-
+        Describe the documentation improvement you would like to suggest.
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Terms
+      description: >-
+        Before submitting the issue, confirm the following:
+      options:
+        - label: >-
+            I have read and followed the project's
+            [Code of Conduct](https://github.com/paduszyk/django-xlsx-serializer/blob/main/docs/CODE_OF_CONDUCT.md) and
+            [Contributing Guide](https://github.com/paduszyk/django-xlsx-serializer/blob/main/docs/CONTRIBUTING.md).
+          required: true
+        - label: >-
+            I checked that this issue isn't a duplicate.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,37 @@
+name: Feature Request
+description: >-
+  Propose new functionality or an enhancement to the existing one.
+labels:
+  - needs triage
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: >-
+        Describe the feature you would like you add or update.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Suggested solution
+      description: >-
+        Tell us about your ideas on how to implement the proposed changes.
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Terms
+      description: >-
+        Before submitting the issue, confirm the following:
+      options:
+        - label: >-
+            I have read and followed the project's
+            [Code of Conduct](https://github.com/paduszyk/django-xlsx-serializer/blob/main/docs/CODE_OF_CONDUCT.md) and
+            [Contributing Guide](https://github.com/paduszyk/django-xlsx-serializer/blob/main/docs/CONTRIBUTING.md).
+          required: true
+        - label: >-
+            I checked that this issue isn't a duplicate.
+          required: true

--- a/.github/ISSUE_TEMPLATE/question-discussion.yml
+++ b/.github/ISSUE_TEMPLATE/question-discussion.yml
@@ -1,0 +1,30 @@
+name: Question / Discussion
+description: >-
+  Use this form if you're not sure how to categorize your issue or if you want to start
+  a conversation on a specific topic related to the project.
+labels:
+  - needs triage
+body:
+  - type: textarea
+    id: question-or-discussion-topic
+    attributes:
+      label: Question or discussion topic
+      description: >-
+        Ask a question or present the topic you'd like to discuss.
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Terms
+      description: >-
+        Before submitting the issue, confirm the following:
+      options:
+        - label: >-
+            I have read and followed the project's
+            [Code of Conduct](https://github.com/paduszyk/django-xlsx-serializer/blob/main/docs/CODE_OF_CONDUCT.md) and
+            [Contributing Guide](https://github.com/paduszyk/django-xlsx-serializer/blob/main/docs/CONTRIBUTING.md).
+          required: true
+        - label: >-
+            I checked that this issue isn't a duplicate.
+          required: true

--- a/.github/ISSUE_TEMPLATE/refactoring-performance.yml
+++ b/.github/ISSUE_TEMPLATE/refactoring-performance.yml
@@ -1,0 +1,29 @@
+name: Refactoring / Performance
+description: >-
+  Propose how to refactor the code or improve its performance.
+labels:
+  - needs triage
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: >-
+        Describe any refactoring or performance improvement you'd like to apply.
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Terms
+      description: >-
+        Before submitting the issue, confirm the following:
+      options:
+        - label: >-
+            I have read and followed the project's
+            [Code of Conduct](https://github.com/paduszyk/django-xlsx-serializer/blob/main/docs/CODE_OF_CONDUCT.md) and
+            [Contributing Guide](https://github.com/paduszyk/django-xlsx-serializer/blob/main/docs/CONTRIBUTING.md).
+          required: true
+        - label: >-
+            I checked that this issue isn't a duplicate.
+          required: true

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,126 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+- Other conduct which could reasonably be considered inappropriate in
+  a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement using any of the
+[reporting services][github-reporting-services] provided by GitHub. All
+complaints will be reviewed and investigated promptly and fairly. All community
+leaders are obligated to respect the privacy and security of the reporter of any
+incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][covenant],
+version 2.0, available [here][covenant-cc]. Community Impact Guidelines were
+inspired by [Mozilla's code of conduct enforcement ladder][mozilla-cc]. For
+answers to common questions about this code of conduct, see the
+[FAQ][covenant-faq]. Translations are available [here][covenant-translations].
+
+[covenant]: https://www.contributor-covenant.org
+[covenant-cc]: https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
+[covenant-faq]: https://www.contributor-covenant.org/faq
+[covenant-translations]: https://www.contributor-covenant.org/translations
+[github-reporting-services]: https://docs.github.com/en/communities/maintaining-your-safety-on-github/reporting-abuse-or-spam
+[mozilla-cc]: https://github.com/mozilla/diversity

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,152 @@
+# Contributing Guide
+
+> If you have no prior experience contributing to open-source projects, you
+> might want to look at the official [GitHub documentation][github-docs] or
+> alternative resources, such as [First Contribution][first-contribution].
+
+You are welcome to contribute by:
+
+- opening issues;
+- creating pull requests;
+- participating in discussions on the existing issues and PRs.
+
+Use our forms and templates, and adhere to the guidelines and checklists
+provided, whether you're opening an issue or submitting a pull request.
+
+## Issues
+
+There are several types of issues one can [open][open-issue] to contribute to
+the project. An issue of each type can be created using a specific form.
+Irrespective of the issue type, all contributors are requested to confirm that
+they are familiar with this guide and the project's [Code of Conduct][code-of-conduct],
+as well as that they have inspected that the issue they want to open is not
+a duplicate.
+
+## Pull Requests
+
+If you're looking to make small tweaks (e.g., fix typos in the documentation),
+feel free to jump straight to creating a pull request. But if it's something
+more substantial, like reporting a bug or suggesting a new feature, it's better
+to start off by opening an issue. This gives everyone in the community a chance
+to chime in and make sure we're all on the same page. Once there's a general
+agreement, you'll be encouraged to submit your pull request.
+
+To contribute to the project via a pull request, follow the instructions:
+
+1. [Fork][fork] the repo, clone it to your machine, and to the project's root.
+2. The project uses a couple of non-Python utilities that can be installed using
+   the Node package manager `npm`. To install them, run:
+
+   ```console
+   npm install
+   ```
+
+   > This assumes you have Node on your machine. If you don't, download and
+   > install the latest release from the official [Node.js][node] website.
+
+3. Create and activate the virtual environment:
+
+   ```console
+   python -m venv .venv && source .venv/bin/activate
+   ```
+
+   > See the [`.python-version`][python-version] file to check the interpreter
+   > version used in the development.
+
+4. Install the package in development mode:
+
+   ```console
+   pip install -e ".[dev]"
+   ```
+
+5. Install [Pre-commit][pre-commit] hooks:
+
+   ```console
+   pre-commit install
+   ```
+
+6. Check the setup by running [Nox][nox]:
+
+   ```console
+   nox
+   ```
+
+   This will inspect the code quality with linters, run the existing tests in
+   different Python/Django/database environments, and measure their coverage.
+   Add the `-l` flag to echo more details on the available Nox sessions.
+
+   > Note that you should have all the versions of Python installed on your
+   > machine. Consider using [`pyenv`][pyenv] to work with multiple Python
+   > interpreters. The app supports the PostgreSQL database, so make sure
+   > a local instance has been set up. Connection data and credentials can be
+   > defined via environment variables (see [`.env.example`][env-example]).
+
+7. Check out a new feature branch and introduce changes.
+
+   > First of all, we request that your PR be as "atomic" as possible. Any
+   > changes that impact the codebase should be accompanied by relevant unit
+   > tests and updates to the documentation. We strive to maintain 100% test
+   > coverage and expect the same from all pull requests. PRs lacking tests will
+   > not be considered for merging.
+
+8. Run Nox again. If all the sessions are successful and the changes are covered
+   by tests, commit your changes and push them to remote.
+
+   > Keep in mind that when you create a pull request, the CI will run all the
+   > checks anyway. Nevertheless, it is still strongly recommended to test
+   > everything locally before pushing to remote and opening a pull request.
+
+9. [Create a pull request][create-pull-request] from the feature branch of your
+   fork to the `main` branch of the upstream repository.
+
+   > Please note that our project adheres to the [Conventional Commits][conventional-commits]
+   > scheme, using the [@commitizen/conventional-commit-types][conventional-commit-types]
+   > set of rules. The [@action-semantic-pull-request][action-semantic-pull-request]
+   > is utilized to validate whether the title of your PR conforms to the
+   > established convention. The number and format of the PR's commits are at
+   > your discretion. When merging the branch from your fork into `main`, all
+   > commits will be squashed into a single commit, with the PR title serving
+   > as the commit subject.
+
+That's it!
+
+Once your pull request passes all CI checks, the project maintainers will
+examine it as quickly as feasible.
+
+## Coding Style
+
+The project uses a variety of tools to enforce uniform and consistent coding
+style throughout the entire codebase.
+
+- [Prettier][prettier] is used for non-Python assets auto-formatting.
+- [Markdownlint][markdownlint] is adopted to lint documentation files.
+- [Ruff][ruff] is used to lint and format the Python codebase.
+- [Mypy][mypy] is incorporated to perform the Python type-checking.
+
+All those tools are in the package's development dependencies, so they can be
+used separately on demand. They are also set up as Pre-commit hooks, so one can
+run them collectively:
+
+```console
+pre-commit run --all-files
+```
+
+[action-semantic-pull-request]: https://github.com/amannn/action-semantic-pull-request
+[code-of-conduct]: https://github.com/paduszyk/django-xlsx-serializer/blob/main/docs/CODE_OF_CONDUCT.md
+[conventional-commit-types]: https://github.com/commitizen/conventional-commit-types
+[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
+[create-pull-request]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
+[env-example]: https://github.com/paduszyk/django-xlsx-serializer/blob/main/.env.example
+[first-contribution]: https://github.com/firstcontributions/first-contributions
+[fork]: https://docs.github.com/en/get-started/quickstart/fork-a-repo
+[github-docs]: https://docs.github.com/en/get-started/quickstart/contributing-to-projects
+[markdownlint]: https://github.com/DavidAnson/markdownlint
+[mypy]: https://mypy.readthedocs.io
+[node]: https://nodejs.org/
+[nox]: https://github.com/wntrblm/nox
+[open-issue]: https://github.com/paduszyk/django-xlsx-serializer/issues/new/choose
+[pre-commit]: https://pre-commit.com
+[prettier]: https://prettier.io
+[pyenv]: https://github.com/pyenv/pyenv
+[python-version]: https://github.com/paduszyk/django-xlsx-serializer/blob/main/.python-version
+[ruff]: https://docs.astral.sh/ruff/

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!-- markdownlint-disable MD013 MD041 -->
+
+## Linked Issues
+
+<!-- Use closing keywords if this PR may resolve an existing issue. -->
+
+## Description
+
+<!-- Provide a concise description of the changes made. -->
+
+## Checklist
+
+<!-- Remove items that are not applicable. -->
+
+- [ ] I have read and followed the project's [Code of Conduct][code-of-conduct] and [Contributing Guide][contributing].
+- [ ] I have checked that similar PRs have not been created before.
+- [ ] I have performed a self-review of my code.
+- [ ] I have added tests covering my fix or feature implementation.
+- [ ] I have made corresponding changes to the documentation.
+- [ ] New and existing unit tests pass locally with my changes.
+- [ ] Any dependent changes have been merged and published in downstream modules.
+
+[code-of-conduct]: https://github.com/paduszyk/django-xlsx-serializer/blob/main/docs/CODE_OF_CONDUCT.md
+[contributing]: https://github.com/paduszyk/django-xlsx-serializer/blob/main/docs/CONTRIBUTING.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,240 @@
 [![Prettier](https://img.shields.io/badge/code%20style-prettier-1E2B33?style=flat-square&logo=Prettier)][prettier]
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-fa6673.svg?style=flat-square&logo=conventional-commits)][conventional-commits]
 
+## Overview
+
+`django-xlsx-serializer` is a [Django][django] application designed to handle
+the data serialization and deserialization between Django models and Microsoft
+Excel 2007+ workbooks. Utilizing the [OpenPyXL][openpyxl] engine, this tool
+provides robust methods to export data from Django databases into XLSX files and
+import data from the files back into the databases. This functionality is
+essential for applications that require data exchange between Django-based
+systems and Excel, facilitating such tasks as data migration, reporting, and
+backups.
+
+## Features
+
+The app allows you to:
+
+- Export Django models from a database to an Excel workbook via the
+  [`dumpdata`][django-dumpdata] command.
+- Populate databases from Excel fixtures using the [`loaddata`][django-loaddata]
+  command.
+- Interact with Excel workbooks (either files or `openpyxl.Workbook` objects)
+  and the database using the Django's core [serialization][django-serialization]
+  utilities.
+
+## Requirements
+
+| Python | Django                  | Database engines    |
+| :----- | :---------------------- | :------------------ |
+| 3.9    | 3.2, 4.0, 4.1, 4.2      | SQLite3, PostgreSQL |
+| 3.10   | 3.2, 4.0, 4.1, 4.2, 5.0 | SQLite3, PostgreSQL |
+| 3.11   | 4.1, 4.2, 5.0           | SQLite3, PostgreSQL |
+| 3.12   | 4.2, 5.0                | SQLite3, PostgreSQL |
+
+All setups require OpenPyXL < 4.
+
+## Installation
+
+The fastest way to add the package to your Python environment is to download and
+install it directly from [PyPI][pypi]. Use `pip`:
+
+```console
+pip install django-xlsx-serializer
+```
+
+or any other dependency manager of your preference.
+
+As soon as the installation is completed, all the app's functionalities can be
+accessed from the `xlsx_serializer` module:
+
+```python
+import xlsx_serializer
+```
+
+> The app is compatible with Excel 2007+ XLSX workbooks only. Adding support for
+> the older XLS format is not planned.
+
+## Django Configuration
+
+The app utilities can be incorporated into your Django project by following one
+of the approaches listed below:
+
+1. Installing the package as an app.
+2. Adding the package to serialization modules.
+3. Registering the app's serializers module from another app.
+
+All of them associate the app's serializer with the `xlsx` format.
+
+### Install as an App
+
+In your project settings module add `xlsx_serializers` to `INSTALLED_APPS`:
+
+```python
+INSTALLED_APPS = [
+    # ...
+    "xlsx_serializer",
+    # ...
+]
+```
+
+### Add to Serialization Modules
+
+In your project settings module update the `SERIALIZATION_MODULES` dictionary:
+
+```python
+SERIALIZATION_MODULES = {
+    # ...
+    "xlsx": "xlsx_serializer",
+    # ...
+}
+```
+
+### Register from Another App
+
+In any of the apps installed in your projects (let us call it `myapp`), register
+the `xlsx_serializer` manually in the app's `ready` hook:
+
+```python
+# myapp/apps.py
+
+from django.apps import AppConfig
+from django.core import serializers
+
+
+class MyAppConfig(AppConfig):
+    name = "myapp"
+
+    def ready(self) -> None:
+        super().ready()
+
+        # ...
+
+        # Register serializers.
+        serializers.register_serializer("xlsx", "xlsx_serializer")
+```
+
+> There are many Django projects using a "core" app for defining project-wide
+> utilities (e.g., custom commands, template tags, etc.). The configuration
+> class of such an app is a good place to apply the code snippet above.
+
+## Usage
+
+### Excel Workbooks vs. Django Models
+
+The app adopts quite intuitive correspondence between Excel workbooks (i.e., the
+collections of worksheets) and Django models:
+
+- A Django model is represented by a single worksheet.
+- In an Excel workbook, the models are identified by worksheet names.
+- Within an Excel worksheet, model instances are represented by rows, while the
+  columns correspond to the model's fields.
+
+### Serialization
+
+Serialization can be run either by the built-in [`dumpdata`][django-dumpdata]
+Django management command:
+
+```console
+python manage.py dumpdata --format xlsx --output dump.xlsx
+```
+
+or from Django interactive shell:
+
+```python
+>>> from django.core import serializers
+>>> from polls.models import Question
+>>> serializers.serialize("xlsx", Question.objects.all(), output="dump.xlsx")
+# Prints: <openpyxl.workbook.workbook.Workbook object at ...>
+```
+
+Both the command and expression shown above save `dump.xlsx` workbook file. The
+latter additionally returns an `openpyxl.Workbook` object, which can be used
+later if necessary (e.g., in development or maintenance scripts).
+
+When serializing, the app creates worksheets named using fully qualified model
+labels. For example, the `Question` model defined in the `polls` app is
+serialized to the "polls.Question" worksheet. Excel does not accept worksheet
+names longer than 31 characters. If the model's label is longer, it's truncated.
+A useful feature allowing you to circumvent this issue is that the output
+worksheet names can be customized using the `model_sheet_names` option. So, the
+command:
+
+```python
+>>> workbook = serialize(
+        "xlsx",
+        Question.objects.all(),
+        model_sheet_names={"polls.Question": "Questions"},
+    )
+>>> workbook
+# Prints: <openpyxl.workbook.workbook.Workbook object at ...>
+```
+
+results in the `polls.Question` model data serialized in the "Questions"
+worksheet. Note that this option is not available when using the app via the
+`dumpdata` command.
+
+> The app inspects each key and value of the `model_sheet_names` dictionary. For
+> the keys, it validates whether they represent valid model identifiers. The
+> values, in turn, are checked to see if they are unique, are not too long, and
+> do not contain invalid characters (`?`, `*`, `:`, `\`, `/`, `[`, `]`).
+
+Other key points:
+
+- `DateField`, `DateTimeField`, and `TimeField` values are serialized as
+  ISO 8601 strings.
+- `JSONField` values are serialized as JSON strings returned by the respective
+  field's encoders.
+- `ManyToManyField` values are serialized as stringified lists of foreign keys.
+- The app supports serialization by using natural keys. If it is triggered (by
+  applying the `--natural-primary`/`--natural-foreign` flags), the natural keys
+  are serialized as stringified tuples (or their lists in the case of
+  many-to-many relations).
+
+### Deserialization
+
+The recommended way of employing the app to load the model data from an Excel
+fixture to the database is to call it via the [`loaddata`][django-loaddata]
+command:
+
+```console
+python manage.py loaddata fixture.xlsx
+```
+
+Deserialization requires the input workbook's worksheets to have names that are
+either the fully qualified labels or model names (case-insensitive). The latter
+can be applied if the model name is unique. For example, if the project uses
+models `polls.Question` and `exams.Question`, the worksheet named "Question"
+will not be deserialized.
+
+Within a worksheet, ensure that the column headers correspond to the field names
+of the respective model. The app ignores a column if it does not represent
+a field. Empty rows and columns surrounding the data range are ignored as well.
+However, the app does not check the data for the missing or invalid values.
+
+Other key points:
+
+- Populating `DateField`, `DateTimeField`, and `TimeField` with timezone support
+  enabled in Django settings requires date/time values to be saved as ISO 8601
+  strings (date/time type values in Excel don't store timezone information).
+- Deserializing `JSONfield` requires values in a format compatible with the JSON
+  decoder of the respective field.
+- In the case of `ManyToManyField` provide string representations of Python
+  lists containing the primary (or natural, see the next bullet) keys of the
+  related objects.
+- The app handles deserialization from natural keys by using `ast.literal_eval`.
+  Make sure to provide the keys that are valid string representations of the
+  corresponding values (i.e., tuples of primitive Python literals; in most
+  cases, they are strings &nddash; if so, use single quotes as text delimiters).
+
+## Contributing
+
+This is an open-source project that embraces contributions of all types. We
+require all contributors to adhere to our [Code of Conduct][code-of-conduct].
+For comprehensive instructions on how to contribute to the project, please refer
+to our [Contributing Guide][contributing].
+
 ## Authors
 
 Created and maintained by Kamil Paduszyński ([@paduszyk][paduszyk]).
@@ -18,13 +252,21 @@ Created and maintained by Kamil Paduszyński ([@paduszyk][paduszyk]).
 
 Released under the [MIT license][license].
 
+[code-of-conduct]: https://github.com/paduszyk/django-xlsx-serializer/blob/main/docs/CODE_OF_CONDUCT.md
 [codecov]: https://app.codecov.io/gh/paduszyk/django-xlsx-serializer
+[contributing]: https://github.com/paduszyk/django-xlsx-serializer/blob/main/docs/CONTRIBUTING.md
 [conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
+[django-dumpdata]: https://docs.djangoproject.com/en/5.0/ref/django-admin/#dumpdata
+[django-loaddata]: https://docs.djangoproject.com/en/5.0/ref/django-admin/#loaddata
+[django-serialization]: https://docs.djangoproject.com/en/5.0/topics/serialization/
+[django]: https://www.djangoproject.com
 [license]: https://github.com/paduszyk/django-xlsx-serializer/blob/main/LICENSE
 [mypy]: https://mypy.readthedocs.io
 [nox]: https://github.com/wntrblm/nox
+[openpyxl]: https://openpyxl.readthedocs.io/en/stable/
 [paduszyk]: https://github.com/paduszyk
 [pre-commit]: https://github.com/paduszyk/django-xlsx-serializer/actions/workflows/pre-commit-run.yml
 [prettier]: https://prettier.io
+[pypi]: https://pypi.org/project/django-xlsx-serializer/
 [python-ci]: https://github.com/paduszyk/django-xlsx-serializer/actions/workflows/python-ci.yml
 [ruff]: https://docs.astral.sh/ruff/

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,10 @@
 # django-xlsx-serializer
 
+[![PyPI: Version](https://img.shields.io/pypi/v/django-xlsx-serializer?style=flat-square&logo=pypi&logoColor=white)][pypi]
+[![PyPI: Python](https://img.shields.io/pypi/pyversions/django-xlsx-serializer?style=flat-square&logo=python&logoColor=white)][pypi]
+[![PyPI: Django](https://img.shields.io/pypi/djversions/django-xlsx-serializer?style=flat-square&color=0C4B33&label=django&logo=django)][pypi]
+[![PyPI: License](https://img.shields.io/pypi/l/django-xlsx-serializer?style=flat-square)][pypi]
+
 [![Pre-commit](https://img.shields.io/github/actions/workflow/status/paduszyk/django-xlsx-serializer/pre-commit-run.yml?style=flat-square&label=pre-commit&logo=pre-commit)][pre-commit]
 [![Python: CI](https://img.shields.io/github/actions/workflow/status/paduszyk/django-xlsx-serializer/python-ci.yml?style=flat-square&logo=github&label=CI)][python-ci]
 [![Codecov](https://img.shields.io/codecov/c/github/paduszyk/django-xlsx-serializer?style=flat-square&logo=codecov)][codecov]


### PR DESCRIPTION
This comprehensively extends the app's README and adds the project's code of conduct, contributing guide, and templates for opening issues of different types and creating pull requests.