### PR TITLE
chore: set up version bumps with Commitizen

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = [
+  "commitizen < 4",
   "django-stubs[compatible-mypy] < 6",
   "nox",
   "pre-commit < 4",
@@ -70,6 +71,16 @@ dev = [
 
 [tool.setuptools.dynamic]
 version = { attr = "xlsx_serializer.__version__" }
+
+# Commitizen
+# https://commitizen-tools.github.io/commitizen/config/
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "0.1.0"
+version_files = [
+  "src/xlsx_serializer/__init__.py:__version__",
+]
 
 # Ruff
 # https://docs.astral.sh/ruff/configuration/


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD041 -->

## Linked Issues

N/A

## Description

This sets up [Commitizen](https://commitizen-tools.github.io/commitizen/) utility to automatically bump the package version based on the latest commit messages (enabled by Conventional Commits and semantic pull requests applied in #1).

## Checklist

<!-- Remove items that are not applicable. -->

- [x] I have read and followed the project's [Code of Conduct][code-of-conduct] and [Contributing Guide][contributing].
- [x] I have checked that similar PRs have not been created before.
- [x] I have performed a self-review of my code.
- [x] Any dependent changes have been merged and published in downstream modules.

[code-of-conduct]: https://github.com/paduszyk/django-xlsx-serializer/blob/main/docs/CODE_OF_CONDUCT.md
[contributing]: https://github.com/paduszyk/django-xlsx-serializer/blob/main/docs/CONTRIBUTING.md
