### PR TITLE
test: adopt new defaults for PT001 and PT023 rules

### DIFF
--- a/tests/commands/test_dumpdata.py
+++ b/tests/commands/test_dumpdata.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dumpdata_command_invokes_serializer(fixture_path: Path) -> None:
     # Arrange.
     DummyModel._default_manager.create()
@@ -33,7 +33,7 @@ def test_dumpdata_command_invokes_serializer(fixture_path: Path) -> None:
     serializer_mock["serialize"].assert_called()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dumpdata_command_warns_if_output_is_not_provided() -> None:
     # Arrange.
     DummyModel._default_manager.create()
@@ -46,7 +46,7 @@ def test_dumpdata_command_warns_if_output_is_not_provided() -> None:
         call_command("dumpdata", format="xlsx")
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dumpdata_command_warns_if_there_is_nothing_to_serialize(
     fixture_path: Path,
 ) -> None:
@@ -61,7 +61,7 @@ def test_dumpdata_command_warns_if_there_is_nothing_to_serialize(
         call_command("dumpdata", format="xlsx", output=fixture_path)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dumpdata_command_saves_workbook_if_output_is_provided(
     fixture_path: Path,
 ) -> None:
@@ -76,7 +76,7 @@ def test_dumpdata_command_saves_workbook_if_output_is_provided(
     workbook_save_mock.assert_called_with(str(fixture_path))
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dumpdata_command_does_not_save_workbook_if_output_is_not_provided() -> None:
     # Arrange.
     DummyModel._default_manager.create()

--- a/tests/commands/test_loaddata.py
+++ b/tests/commands/test_loaddata.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_loaddata_command_invokes_deserializer(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ def _media_setup_and_cleanup() -> Generator[None, None, None]:
             shutil.rmtree(settings.MEDIA_ROOT)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_file() -> Callable[[str], mock.Mock]:
     def _mock_file(filename: str) -> mock.Mock:
         file_mock = mock.MagicMock(spec=File)
@@ -39,7 +39,7 @@ def mock_file() -> Callable[[str], mock.Mock]:
     return _mock_file
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_image() -> Callable[[str], mock.Mock]:
     def _mock_image(filename: str) -> mock.Mock:
         image_file_mock = mock.MagicMock(spec=ImageFile)
@@ -50,6 +50,6 @@ def mock_image() -> Callable[[str], mock.Mock]:
     return _mock_image
 
 
-@pytest.fixture()
+@pytest.fixture
 def fixture_path(tmp_path: Path) -> Path:
     return tmp_path / "fixture.xlsx"

--- a/tests/core/test_deserializer.py
+++ b/tests/core/test_deserializer.py
@@ -152,7 +152,7 @@ def test_deserializer_reads_empty_cells_as_none(fixture_path: Path) -> None:
         "None",
     ],
 )
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_django_handles_empty_non_nullable_fields(
     fixture_path: Path,
     empty_value: str | None,

--- a/tests/core/test_serializer.py
+++ b/tests/core/test_serializer.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_serializer_saves_workbook_if_stream_is_valid(fixture_path: Path) -> None:
     # Arrange.
     obj = DummyModel._default_manager.create()
@@ -40,7 +40,7 @@ def test_serializer_raises_error_if_stream_is_invalid() -> None:
         serialize("xlsx", [], stream=mock.ANY)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_serializer_applies_shortened_sheet_name_if_model_label_is_too_long() -> None:
     # Arrange.
     obj = LabelLongerThan31CharactersModel._default_manager.create()
@@ -52,7 +52,7 @@ def test_serializer_applies_shortened_sheet_name_if_model_label_is_too_long() ->
     assert "LabelLongerThan31CharactersMode" in wb
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_serializer_emits_runtime_warning_if_model_label_is_too_long() -> None:
     # Arrange.
     obj = LabelLongerThan31CharactersModel._default_manager.create()
@@ -72,7 +72,7 @@ def test_serializer_emits_runtime_warning_if_model_label_is_too_long() -> None:
     assert "LabelLongerThan31CharactersMode" in wb
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_serializer_raises_error_if_conflicting_default_sheet_names_are_found() -> None:
     # Arrange.
     obj_a = LabelLongerThan31CharactersModelA._default_manager.create()
@@ -91,7 +91,7 @@ def test_serializer_raises_error_if_conflicting_default_sheet_names_are_found() 
         serialize("xlsx", [obj_a, obj_b])
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_serializer_applies_sheet_name_from_model_sheet_names_option() -> None:
     # Arrange.
     obj = DummyModel._default_manager.create()
@@ -218,7 +218,7 @@ def test_serializer_raises_error_if_sheet_name_from_model_sheet_names_option_con
         )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_serializer_removes_sheets_not_added_by_itself() -> None:
     # Arrange.
     obj_1 = DummyModel._default_manager.create()

--- a/tests/fields/test_auto_fields.py
+++ b/tests/fields/test_auto_fields.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_auto_field_is_deserialized(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -31,7 +31,7 @@ def test_auto_field_is_deserialized(fixture_path: Path) -> None:
     assert obj.auto_field == 42
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_auto_field_is_serialized() -> None:
     # Arrange.
     obj = AutoFieldModel._default_manager.create()
@@ -44,7 +44,7 @@ def test_auto_field_is_serialized() -> None:
     assert wb["tests.AutoFieldModel"]["A2"].value == obj.pk
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_big_auto_field_is_deserialized(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -61,7 +61,7 @@ def test_big_auto_field_is_deserialized(fixture_path: Path) -> None:
     assert obj.big_auto_field == 42
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_big_auto_field_is_serialized() -> None:
     # Arrange.
     obj = BigAutoFieldModel._default_manager.create()
@@ -74,7 +74,7 @@ def test_big_auto_field_is_serialized() -> None:
     assert wb["tests.BigAutoFieldModel"]["A2"].value == obj.pk
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_small_auto_field_is_deserialized(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -91,7 +91,7 @@ def test_small_auto_field_is_deserialized(fixture_path: Path) -> None:
     assert obj.small_auto_field == 42
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_small_auto_field_is_serialized() -> None:
     # Arrange.
     obj = SmallAutoFieldModel._default_manager.create()

--- a/tests/fields/test_boolean_fields.py
+++ b/tests/fields/test_boolean_fields.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
         True,
     ],
 )
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_boolean_field_is_deserialized(fixture_path: Path, field_value: bool) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -47,7 +47,7 @@ def test_boolean_field_is_deserialized(fixture_path: Path, field_value: bool) ->
         True,
     ],
 )
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_boolean_field_is_serialized(field_value: bool) -> None:
     # Arrange.
     obj = BooleanFieldModel._default_manager.create(pk=1, boolean_field=field_value)

--- a/tests/fields/test_file_fields.py
+++ b/tests/fields/test_file_fields.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from unittest import mock
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_file_field_is_deserialized(
     fixture_path: Path,
     mock_file: Callable[[str], mock.Mock],
@@ -37,7 +37,7 @@ def test_file_field_is_deserialized(
     assert obj.file_field == mock_file("file.txt")
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_file_field_is_serialized(mock_file: Callable[[str], mock.Mock]) -> None:
     # Arrange.
     obj = FileFieldModel._default_manager.create(pk=1, file_field=mock_file("file.txt"))
@@ -52,7 +52,7 @@ def test_file_field_is_serialized(mock_file: Callable[[str], mock.Mock]) -> None
     assert wb["tests.FileFieldModel"]["B2"].value == "file.txt"
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_image_field_is_deserialized(
     fixture_path: Path,
     mock_image: Callable[[str], mock.Mock],
@@ -74,7 +74,7 @@ def test_image_field_is_deserialized(
     assert obj.image_field == mock_image("image.png")
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_image_field_is_serialized(mock_image: Callable[[str], mock.Mock]) -> None:
     # Arrange.
     obj = ImageFieldModel._default_manager.create(
@@ -92,7 +92,7 @@ def test_image_field_is_serialized(mock_image: Callable[[str], mock.Mock]) -> No
     assert wb["tests.ImageFieldModel"]["B2"].value == "image.png"
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_file_path_field_is_deserialized(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -111,7 +111,7 @@ def test_file_path_field_is_deserialized(fixture_path: Path) -> None:
     assert obj.file_path_field == "file.txt"
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_file_path_field_is_serialized() -> None:
     # Arrange.
     obj = FilePathFieldModel._default_manager.create(pk=1, file_path_field="file.txt")

--- a/tests/fields/test_numeric_fields.py
+++ b/tests/fields/test_numeric_fields.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_integer_field_is_deserialized(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -43,7 +43,7 @@ def test_integer_field_is_deserialized(fixture_path: Path) -> None:
     assert obj.integer_field == 42
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_integer_field_is_serialized() -> None:
     # Arrange.
     obj = IntegerFieldModel._default_manager.create(pk=1, integer_field=42)
@@ -58,7 +58,7 @@ def test_integer_field_is_serialized() -> None:
     assert wb["tests.IntegerFieldModel"]["B2"].value == 42
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_big_integer_field_is_deserialized(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -77,7 +77,7 @@ def test_big_integer_field_is_deserialized(fixture_path: Path) -> None:
     assert obj.big_integer_field == 42
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_big_integer_field_is_serialized() -> None:
     # Arrange.
     obj = BigIntegerFieldModel._default_manager.create(pk=1, big_integer_field=42)
@@ -92,7 +92,7 @@ def test_big_integer_field_is_serialized() -> None:
     assert wb["tests.BigIntegerFieldModel"]["B2"].value == 42
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_small_integer_field_is_deserialized(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -111,7 +111,7 @@ def test_small_integer_field_is_deserialized(fixture_path: Path) -> None:
     assert obj.small_integer_field == 42
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_small_integer_field_is_serialized() -> None:
     # Arrange.
     obj = SmallIntegerFieldModel._default_manager.create(pk=1, small_integer_field=42)
@@ -126,7 +126,7 @@ def test_small_integer_field_is_serialized() -> None:
     assert wb["tests.SmallIntegerFieldModel"]["B2"].value == 42
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_positive_integer_field_is_deserialized(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -145,7 +145,7 @@ def test_positive_integer_field_is_deserialized(fixture_path: Path) -> None:
     assert obj.positive_integer_field == 42
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_positive_integer_field_is_serialized() -> None:
     # Arrange.
     obj = PositiveIntegerFieldModel._default_manager.create(
@@ -163,7 +163,7 @@ def test_positive_integer_field_is_serialized() -> None:
     assert wb["tests.PositiveIntegerFieldModel"]["B2"].value == 42
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_positive_big_integer_field_is_deserialized(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -182,7 +182,7 @@ def test_positive_big_integer_field_is_deserialized(fixture_path: Path) -> None:
     assert obj.positive_big_integer_field == 42
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_positive_big_integer_field_is_serialized() -> None:
     # Arrange.
     obj = PositiveBigIntegerFieldModel._default_manager.create(
@@ -200,7 +200,7 @@ def test_positive_big_integer_field_is_serialized() -> None:
     assert wb["PositiveBigIntegerFieldModel"]["B2"].value == 42
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_positive_small_integer_field_is_deserialized(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -219,7 +219,7 @@ def test_positive_small_integer_field_is_deserialized(fixture_path: Path) -> Non
     assert obj.positive_small_integer_field == 42
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_positive_small_integer_field_is_serialized() -> None:
     # Arrange.
     obj = PositiveSmallIntegerFieldModel._default_manager.create(
@@ -237,7 +237,7 @@ def test_positive_small_integer_field_is_serialized() -> None:
     assert wb["PositiveSmallIntegerFieldModel"]["B2"].value == 42
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_decimal_field_is_deserialized(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -256,7 +256,7 @@ def test_decimal_field_is_deserialized(fixture_path: Path) -> None:
     assert obj.decimal_field == Decimal("4.2")
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_decimal_field_is_serialized() -> None:
     # Arrange.
     obj = DecimalFieldModel._default_manager.create(pk=1, decimal_field=Decimal("4.2"))
@@ -271,7 +271,7 @@ def test_decimal_field_is_serialized() -> None:
     assert wb["tests.DecimalFieldModel"]["B2"].value == Decimal("4.2")
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_float_field_is_deserialized(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -290,7 +290,7 @@ def test_float_field_is_deserialized(fixture_path: Path) -> None:
     assert obj.float_field == 4.2
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_float_field_is_serialized() -> None:
     # Arrange.
     obj = FloatFieldModel._default_manager.create(pk=1, float_field=4.2)

--- a/tests/fields/test_related_fields.py
+++ b/tests/fields/test_related_fields.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_foreign_key_field_is_deserialized_with_auto_fks(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -54,7 +54,7 @@ def test_foreign_key_field_is_deserialized_with_auto_fks(fixture_path: Path) -> 
     assert obj.to_nk_model_field == related_natural_key_model_obj
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_foreign_key_field_is_deserialized_with_natural_fks(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -89,7 +89,7 @@ def test_foreign_key_field_is_deserialized_with_natural_fks(fixture_path: Path) 
     assert obj.to_nk_model_field == related_natural_key_model_obj
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_foreign_key_field_is_serialized_with_use_natural_fks_disabled() -> None:
     # Arrange
     obj = ForeignKeyModel._default_manager.create(
@@ -114,7 +114,7 @@ def test_foreign_key_field_is_serialized_with_use_natural_fks_disabled() -> None
     assert wb["tests.ForeignKeyModel"]["C2"].value == 2
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_foreign_key_field_is_serialized_with_use_natural_fks_enabled() -> None:
     # Arrange
     obj = ForeignKeyModel._default_manager.create(
@@ -138,7 +138,7 @@ def test_foreign_key_field_is_serialized_with_use_natural_fks_enabled() -> None:
     assert wb["tests.ForeignKeyModel"]["C2"].value == "('value', 42)"
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_one_to_one_field_is_deserialized_with_auto_fks(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -172,7 +172,7 @@ def test_one_to_one_field_is_deserialized_with_auto_fks(fixture_path: Path) -> N
     assert obj.to_nk_model_field == related_natural_key_model_obj
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_one_to_one_field_is_deserialized_with_natural_fks(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -207,7 +207,7 @@ def test_one_to_one_field_is_deserialized_with_natural_fks(fixture_path: Path) -
     assert obj.to_nk_model_field == related_natural_key_model_obj
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_one_to_one_field_is_serialized_with_use_natural_fks_disabled() -> None:
     # Arrange
     obj = OneToOneFieldModel._default_manager.create(
@@ -232,7 +232,7 @@ def test_one_to_one_field_is_serialized_with_use_natural_fks_disabled() -> None:
     assert wb["tests.OneToOneFieldModel"]["C2"].value == 2
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_one_to_one_field_is_serialized_with_use_natural_foreign_keys_enabled() -> None:
     # Arrange
     obj = OneToOneFieldModel._default_manager.create(
@@ -256,7 +256,7 @@ def test_one_to_one_field_is_serialized_with_use_natural_foreign_keys_enabled() 
     assert wb["tests.OneToOneFieldModel"]["C2"].value == "('value', 42)"
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_many_to_many_field_is_deserialized_with_auto_fks(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -302,7 +302,7 @@ def test_many_to_many_field_is_deserialized_with_auto_fks(fixture_path: Path) ->
     ]
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_many_to_many_field_is_deserialized_with_natural_fks(fixture_path: Path) -> None:  # fmt: skip
     # Arrange.
     wb = openpyxl.Workbook()
@@ -348,7 +348,7 @@ def test_many_to_many_field_is_deserialized_with_natural_fks(fixture_path: Path)
     ]
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_many_to_many_field_is_serialized_with_use_natural_fks_disabled() -> None:
     # Arrange.
     obj = ManyToManyFieldModel._default_manager.create(pk=1)
@@ -381,7 +381,7 @@ def test_many_to_many_field_is_serialized_with_use_natural_fks_disabled() -> Non
     assert wb["tests.ManyToManyFieldModel"]["C2"].value == "[3, 4]"
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_many_to_many_field_is_serialized_with_use_natural_fks_enabled() -> None:
     # Arrange.
     obj = ManyToManyFieldModel._default_manager.create(pk=1)

--- a/tests/fields/test_string_fields.py
+++ b/tests/fields/test_string_fields.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_char_field_is_deserialized(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -33,7 +33,7 @@ def test_char_field_is_deserialized(fixture_path: Path) -> None:
     assert obj.char_field == "value"
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_char_field_is_serialized() -> None:
     # Arrange.
     obj = CharFieldModel._default_manager.create(pk=1, char_field="value")
@@ -48,7 +48,7 @@ def test_char_field_is_serialized() -> None:
     assert wb["tests.CharFieldModel"]["B2"].value == "value"
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_text_field_is_deserialized(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -67,7 +67,7 @@ def test_text_field_is_deserialized(fixture_path: Path) -> None:
     assert obj.text_field == "value"
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_text_field_is_serialized() -> None:
     # Arrange.
     obj = TextFieldModel._default_manager.create(pk=1, text_field="value")
@@ -82,7 +82,7 @@ def test_text_field_is_serialized() -> None:
     assert wb["tests.TextFieldModel"]["B2"].value == "value"
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_slug_field_is_deserialized(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -101,7 +101,7 @@ def test_slug_field_is_deserialized(fixture_path: Path) -> None:
     assert obj.slug_field == "value"
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_slug_field_is_serialized() -> None:
     # Arrange.
     obj = SlugFieldModel._default_manager.create(pk=1, slug_field="value")

--- a/tests/fields/test_timestamp_fields.py
+++ b/tests/fields/test_timestamp_fields.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_date_field_is_deserialized(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -40,7 +40,7 @@ def test_date_field_is_deserialized(fixture_path: Path) -> None:
     assert obj.date_field == datetime.date(2024, 4, 2)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_date_field_is_serialized() -> None:
     # Arrange.
     obj = DateFieldModel._default_manager.create(
@@ -58,7 +58,7 @@ def test_date_field_is_serialized() -> None:
     assert wb["tests.DateFieldModel"]["B2"].value == "2024-04-02"
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_time_field_is_deserialized(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -77,7 +77,7 @@ def test_time_field_is_deserialized(fixture_path: Path) -> None:
     assert obj.time_field == datetime.time(22, 44, 42)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_time_field_is_serialized() -> None:
     # Arrange.
     obj = TimeFieldModel._default_manager.create(
@@ -98,7 +98,7 @@ def test_time_field_is_serialized() -> None:
 @override_settings(
     USE_TZ=False,
 )
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_datetime_field_is_deserialized_with_tz_disabled(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -120,7 +120,7 @@ def test_datetime_field_is_deserialized_with_tz_disabled(fixture_path: Path) -> 
 @override_settings(
     USE_TZ=True,
 )
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_datetime_field_is_deserialized_with_tz_enabled(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -145,7 +145,7 @@ def test_datetime_field_is_deserialized_with_tz_enabled(fixture_path: Path) -> N
 @override_settings(
     USE_TZ=False,
 )
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_datetime_field_is_serialized_with_tz_disabled() -> None:
     # Arrange.
     obj = DateTimeFieldModel._default_manager.create(
@@ -166,7 +166,7 @@ def test_datetime_field_is_serialized_with_tz_disabled() -> None:
 @override_settings(
     USE_TZ=True,
 )
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_datetime_field_is_serialized_with_tz_enabled() -> None:
     # Arrange.
     obj = DateTimeFieldModel._default_manager.create(
@@ -187,7 +187,7 @@ def test_datetime_field_is_serialized_with_tz_enabled() -> None:
     assert wb["tests.DateTimeFieldModel"]["B2"].value == "2024-04-02T22:44:42+02:00"
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_duration_field_is_deserialized(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -206,7 +206,7 @@ def test_duration_field_is_deserialized(fixture_path: Path) -> None:
     assert obj.duration_field == datetime.timedelta(hours=4, minutes=2, seconds=42)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_duration_field_is_serialized() -> None:
     # Arrange.
     obj = DurationFieldModel._default_manager.create(

--- a/tests/fields/test_utility_fields.py
+++ b/tests/fields/test_utility_fields.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_email_field_is_deserialized(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -40,7 +40,7 @@ def test_email_field_is_deserialized(fixture_path: Path) -> None:
     assert obj.email_field == "92403542+paduszyk@users.noreply.github.com."
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_email_field_is_serialized() -> None:
     # Arrange.
     obj = EmailFieldModel._default_manager.create(
@@ -58,7 +58,7 @@ def test_email_field_is_serialized() -> None:
     assert wb["tests.EmailFieldModel"]["B2"].value == "92403542+paduszyk@users.noreply.github.com."  # fmt: skip
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_generic_ip_address_field_is_deserialized(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -77,7 +77,7 @@ def test_generic_ip_address_field_is_deserialized(fixture_path: Path) -> None:
     assert obj.generic_ip_address_field == "127.0.0.1"
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_generic_ip_address_field_is_serialized() -> None:
     # Arrange.
     obj = GenericIPAddressFieldModel._default_manager.create(
@@ -95,7 +95,7 @@ def test_generic_ip_address_field_is_serialized() -> None:
     assert wb["GenericIPAddressFieldModel"]["B2"].value == "127.0.0.1"
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_json_field_is_deserialized(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -114,7 +114,7 @@ def test_json_field_is_deserialized(fixture_path: Path) -> None:
     assert obj.json_field == {"key_1": 42, "key_2": [42], "key_3": {"4": 2}}
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_json_field_is_serialized() -> None:
     # Arrange.
     obj = JSONFieldModel._default_manager.create(
@@ -132,7 +132,7 @@ def test_json_field_is_serialized() -> None:
     assert wb["tests.JSONFieldModel"]["B2"].value == '{"key_1": 42, "key_2": [42], "key_3": {"4": 2}}'  # fmt: skip
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_url_field_is_deserialized(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -151,7 +151,7 @@ def test_url_field_is_deserialized(fixture_path: Path) -> None:
     assert obj.url_field == "https://github.com/paduszyk/django-xlsx-serializer"
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_url_field_is_serialized() -> None:
     # Arrange.
     obj = URLFieldModel._default_manager.create(
@@ -169,7 +169,7 @@ def test_url_field_is_serialized() -> None:
     assert wb["tests.URLFieldModel"]["B2"].value == "https://github.com/paduszyk/django-xlsx-serializer"  # fmt: skip
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_uuid_field_is_deserialized(fixture_path: Path) -> None:
     # Arrange.
     wb = openpyxl.Workbook()
@@ -188,7 +188,7 @@ def test_uuid_field_is_deserialized(fixture_path: Path) -> None:
     assert obj.uuid_field == uuid.UUID("ebc54031-d5ae-4367-8033-e6fbaa3ca8d7")
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_uuid_field_is_serialized() -> None:
     # Arrange.
     obj = UUIDFieldModel._default_manager.create(


### PR DESCRIPTION
## Description

Due to updates released in Ruff 0.6.1.

## Checklist

- [x] I have read and followed the project's [Code of Conduct][code-of-conduct] and [Contributing Guide][contributing].
- [x] I have checked that similar PRs have not been created before.
- [x] I have performed a self-review of my code.
- [x] I have added tests covering my fix or feature implementation.
- [x] I have made corresponding changes to the documentation.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

[code-of-conduct]: https://github.com/paduszyk/django-xlsx-serializer/blob/main/docs/CODE_OF_CONDUCT.md
[contributing]: https://github.com/paduszyk/django-xlsx-serializer/blob/main/docs/CONTRIBUTING.md
