### PR TITLE
fix(ruff): remove target-version option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,9 +105,6 @@ version_files = [
 # https://docs.astral.sh/ruff/rules/
 # https://docs.astral.sh/ruff/settings/
 
-[tool.ruff]
-target-version = "py39"
-
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = ["ANN", "D"]

--- a/scripts/format_nox_sessions.py
+++ b/scripts/format_nox_sessions.py
@@ -4,7 +4,10 @@ import argparse
 import json
 import subprocess
 import sys
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 SESSION_NAME_FORMATS = {
     "install": "Install package (Python {python})",

--- a/src/xlsx_serializer/core.py
+++ b/src/xlsx_serializer/core.py
@@ -339,7 +339,7 @@ class Deserializer:
             python_model_objects = [
                 {
                     "model": opts.label_lower,
-                    "fields": dict(zip(sheet_columns, worksheet_row)),
+                    "fields": dict(zip(sheet_columns, worksheet_row, strict=True)),
                 }
                 for worksheet_row in sheet.iter_rows(
                     min_row=sheet.min_row + 1,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import shutil
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
@@ -14,7 +14,7 @@ from django.core.files.images import ImageFile
 from django.test.utils import override_settings
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Callable, Generator
 
 
 @pytest.fixture(autouse=True)

--- a/tests/fields/test_file_fields.py
+++ b/tests/fields/test_file_fields.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 import openpyxl
 import pytest
@@ -11,6 +11,7 @@ from django.core.serializers import serialize
 from tests.models import FileFieldModel, FilePathFieldModel, ImageFieldModel
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
     from unittest import mock
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD041 -->

## Linked Issues

n/a

## Description

Removes `target-version` specification for Ruff.

The value was incorrect as incompatible with `requires-python` and Trove classifiers. Besides Ruff's [docs](https://docs.astral.sh/ruff/settings/#target-version) recommends to use `requires-python` setting only.

## Checklist

<!-- Remove items that are not applicable. -->

- [ ] I have read and followed the project's [Code of Conduct][code-of-conduct] and [Contributing Guide][contributing].
- [ ] I have checked that similar PRs have not been created before.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests covering my fix or feature implementation.
- [ ] I have made corresponding changes to the documentation.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

[code-of-conduct]: https://github.com/paduszyk/django-xlsx-serializer/blob/main/docs/CODE_OF_CONDUCT.md
[contributing]: https://github.com/paduszyk/django-xlsx-serializer/blob/main/docs/CONTRIBUTING.md
